### PR TITLE
Modify card component

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1029,39 +1029,104 @@
 
       <div class="ly_footer_widget6fr">
         <h2 class="ly_footer_headerTitle">最新の投稿</h2>
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./single.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">Read me（サンプル：投稿ページ）</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./page.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：固定ページ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./archive.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：アーカイブ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
+				<div class="bl_cardUnit bl_cardUnit__1col">
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./single.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">Read me</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-08">2023/11/08</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：固定ページ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./archive.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：アーカイブ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+				</div>
+				<!-- /.bl_cardUnit bl_cardUnit__1col -->
       </div>
       <!-- /.ly_footer_widget6fr -->
 

--- a/docs/archive.html
+++ b/docs/archive.html
@@ -576,70 +576,178 @@
     <main class="ly_mainArea_content ly_mainArea_content__left" id="anchor_mainContent">
       <h1 class="el_header_lv1">アーカイブ名（年月、カテゴリなど）</h1>
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./single.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">投稿ページ(Read me)</h2>
-            <time class="bl_card_date" datetime="2020-11-22">2020年11月22日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+			<div class="bl_cardUnit bl_cardUnit__1col">
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./page.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">固定ページ</h2>
-            <time class="bl_card_date" datetime="2020-10-23">2020年10月23日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./single.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">Read me</h2>
+							<p class="bl_card_content">
+								ここでは、このプロジェクトの主旨や注意事項等についてまとめてあります。
+								また、投稿ページのサンプルも兼ねています。
+							</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-08">2023/11/08</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./archive.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">アーカイブ</h2>
-            <time class="bl_card_date" datetime="2020-09-16">2020年9月16日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./page.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：固定ページ</h2>
+							<p class="bl_card_content">
+								このページは 固定ページ用のサンプルページとなります。
+								ここでは、本テーマで使用しているコンポーネントの一部を、一覧として掲示しております。
+							</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">コンポーネント</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./search.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">検索</h2>
-            <time class="bl_card_date" datetime="2020-08-01">2020年8月1日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./archive.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：アーカイブ</h2>
+							<p class="bl_card_content">このページは アーカイブページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./404.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">404</h2>
-            <time class="bl_card_date" datetime="2020-07-16">2020年7月16日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./search.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：検索</h2>
+							<p class="bl_card_content">このページは 検索ページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
+
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./404.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：404</h2>
+							<p class="bl_card_content">このページは 404ページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
+
+			</div>
+			<!-- /.bl_cardUnit bl_cardUnit__1col -->
 
       <nav class="bl_pager" aria-label="ページ割り">
         <div class="bl_pager_left">
@@ -1144,39 +1252,104 @@
 
       <div class="ly_footer_widget6fr">
         <h2 class="ly_footer_headerTitle">最新の投稿</h2>
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./single.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">Read me（サンプル：投稿ページ）</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./page.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：固定ページ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./archive.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：アーカイブ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
+				<div class="bl_cardUnit bl_cardUnit__1col">
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./single.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">Read me</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-08">2023/11/08</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：固定ページ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./archive.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：アーカイブ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+				</div>
+				<!-- /.bl_cardUnit bl_cardUnit__1col -->
       </div>
       <!-- /.ly_footer_widget6fr -->
 

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -950,10 +950,10 @@ html:has(dialog[open]) {
 /* ≡≡≡ ❒ bl_card ❒ ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
   ■ 概要
     カードのコンポーネント、下記の場所で使用される
-      + トップページの記事一覧（サムネイル、カテゴリ、タイトル、要旨、投稿日）
-      + フッターの最新記事（タイトル、カテゴリ、投稿日）
-      + アーカイブページの記事一覧（カテゴリ、タイトル、要旨、投稿日）
-      + 検索ページでヒットした記事一覧（カテゴリ、タイトル、要旨、投稿日）
+      + トップページの記事一覧（サムネイル、タイトル、要旨、投稿日、カテゴリ）
+      + フッターの最新記事（タイトル、投稿日、カテゴリ）
+      + アーカイブページの記事一覧（タイトル、要旨、投稿日、カテゴリ）
+      + 検索ページでヒットした記事一覧（タイトル、要旨、投稿日、カテゴリ）
   ■ 構成
     bl_card_wrapper : ラッパー
       bl_card : ベース
@@ -967,10 +967,29 @@ html:has(dialog[open]) {
           bl_card_content : 投稿の要旨
           bl_card_date : 投稿日
 ---------------------------------------------------------------------------- */
-.bl_card_wrapper {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+
+.bl_card__sticky .bl_card_title::before {
+	display: inline-block;
+	width: 1em;
+	height: 1em;
+	margin-inline-end: 0.125em;
+	vertical-align: -0.125em;
+	content: "";
+	background-image: url('data:image/svg+xml;utf-8,<svg viewBox="0 0 24 24" fill="red" xmlns="http://www.w3.org/2000/svg"><path d="M12 22C6.5 22 2 17.5 2 12C2 6.5 6.5 2 12 2C17.5 2 22 6.5 22 12C22 17.5 17.5 22 12 22ZM12 3.5C7.3 3.5 3.5 7.3 3.5 12C3.5 16.7 7.3 20.5 12 20.5C16.7 20.5 20.5 16.7 20.5 12C20.5 7.3 16.7 3.5 12 3.5ZM12 17.5C12.5523 17.5 13 17.0523 13 16.5C13 15.9477 12.5523 15.5 12 15.5C11.4477 15.5 11 15.9477 11 16.5C11 17.0523 11.4477 17.5 12 17.5ZM11.3008 6.5H12.8008V14H11.3008V6.5Z"/></svg>');
 }
+
+/*
+.bl_card__sticky::after {
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	display: block;
+	width: 16px;
+	height: 16px;
+	content: "";
+	background-image: url('data:image/svg+xml;utf-8,<svg viewBox="0 0 24 24" fill="red" xmlns="http://www.w3.org/2000/svg"><path d="M12 22C6.5 22 2 17.5 2 12C2 6.5 6.5 2 12 2C17.5 2 22 6.5 22 12C22 17.5 17.5 22 12 22ZM12 3.5C7.3 3.5 3.5 7.3 3.5 12C3.5 16.7 7.3 20.5 12 20.5C16.7 20.5 20.5 16.7 20.5 12C20.5 7.3 16.7 3.5 12 3.5ZM12 17.5C12.5523 17.5 13 17.0523 13 16.5C13 15.9477 12.5523 15.5 12 15.5C11.4477 15.5 11 15.9477 11 16.5C11 17.0523 11.4477 17.5 12 17.5ZM11.3008 6.5H12.8008V14H11.3008V6.5Z"/></svg>');
+}
+*/
 
 /*
  * カスタムプロパティ `--card_r` は カード内のR値で、自身の幅に応じ変化
@@ -984,95 +1003,181 @@ html:has(dialog[open]) {
     min(8px, calc(100% - 40px) * 9999, calc(120px - 100%) * 9999),
     min(12px, calc(100% - 120px) * 9999)
   );
+	--sp: 16px;
 
-  display: block;
+  /* 最上位にある rem を基準に、残りは em 単位を使用（`__small` の場合とで調整 ） */
+	position: relative;
+	display: block;
   font-size: 1rem;
-  border: var(--sc_border_divider);
-  border-radius: var(--card_r, 0);
+  color: var(--sc_txt_body);
+
+	&.bl_card__small {
+		font-size: 0.8rem;
+		color: var(--sc_txt_body__small);
+
+		&.bl_card__clickable > .bl_card_main > .bl_card_body {
+			background-color: var(--sc_bg_body__primary);
+
+			&:hover {
+				background-color: var(--sc_bg_body__secondary);
+			}
+		}
+	}
+
+	&.bl_card__clickable > .bl_card_main {
+		& > .bl_card_body {
+			background-color: var(--sc_bg_body__tertiary);
+
+			&:hover {
+				background-color: var(--sc_bg_body__secondary);
+			}
+		}
+
+		& > .bl_card_thumbnail:hover + .bl_card_body {
+					background-color: var(--sc_bg_body__secondary);
+		}
+	}
+
+	& > .bl_card_main {
+		display: block;
+		text-decoration: none;
+		border-top-left-radius: var(--card_r, 0);
+		border-top-right-radius: var(--card_r, 0);
+
+		& > *:first-child {
+			overflow: hidden;
+			border: var(--sc_border_divider);
+			border-bottom: none;
+			border-top-left-radius: var(--card_r, 0);
+			border-top-right-radius: var(--card_r, 0);
+		}
+
+		& > *:not(:first-child) {
+			border-right: var(--sc_border_divider);
+			border-left: var(--sc_border_divider);
+		}
+
+		& > .bl_card_thumbnail > img {
+			width: 100%;
+			height: auto;
+			aspect-ratio: 16/9;
+			object-fit: cover;
+			vertical-align: bottom;
+		}
+
+		& > .bl_card_body {
+			padding: 2px var(--sp);
+
+			& > .bl_card_title {
+				margin: 0;
+				margin-bottom: var(--space_1, 0.5rem);
+				font-size: 1.5em;
+				font-weight: 500;
+				line-height: 1.5;
+				letter-spacing: 0.04em;
+
+				@media (min-width: 960px) {
+					font-size: 1.75em;
+					font-weight: 400;
+				}
+			}
+
+			& > .bl_card_content {
+				font-size: 0.875em;
+				font-weight: 400;
+				line-height: 1.7;
+				letter-spacing: 0.04em;
+			}
+
+			& > .bl_card_dates {
+				display: flex;
+				flex-flow: row wrap;
+				gap: 0.2rem 1rem;
+				margin-top: var(--space_1, 0.5rem);
+				margin-bottom: var(--space_1, 0.5rem);
+
+				& .bl_card_date {
+					flex: none;
+
+					& > span,
+					& > time {
+						font-size: 0.75em;
+						font-weight: 400;
+						line-height: 1.7;
+						color: var(--sc_txt_desc);
+						letter-spacing: 0.02em;
+					}
+
+					& > span::after {
+						content: ":";
+					}
+				}
+			}
+		}
+
+		&:not(:has( + .bl_card_meta)) > *:last-child {
+			overflow: hidden;
+			border-bottom: var(--sc_border_divider);
+			border-bottom-right-radius: var(--card_r, 0);
+			border-bottom-left-radius: var(--card_r, 0);
+		}
+	}
+
+	&.bl_card__small > .bl_card_meta {
+		background-color: var(--sc_bg_body__primary);
+	}
+
+	& > .bl_card_meta {
+		display: block;
+		background-color: var(--sc_bg_body__tertiary);
+		border: var(--sc_border_divider);
+		border-top-style: dashed;
+		border-bottom-right-radius: var(--card_r, 0);
+		border-bottom-left-radius: var(--card_r, 0);
+
+		& > .bl_card_categories {
+			display: flex;
+			flex-flow: row wrap;
+			gap: 0.3rem;
+			padding: 8px var(--sp);
+			margin: 0;
+			list-style-type: none;
+
+			& > li {
+				flex: none;
+
+				& > a {
+					padding: 0.1em 1em;
+					font-size: 0.75em;
+					font-weight: 400;
+					line-height: 1.7;
+					color: var(--sc_txt_body__small);
+					text-align: center;
+					text-decoration: none;
+					letter-spacing: 0.02em;
+					cursor: pointer;
+					border: var(--sc_border_divider);
+					border-radius: 9999px;
+					transition: .25s;
+
+					&:hover,
+					&:active {
+						background-color: var(--sc_bg_body__secondary);
+					}
+				}
+			}
+		}
+	}
 }
 
-.bl_card.bl_card__clickable {
-  text-decoration: none;
-  background-color: var(--sc_bg_body__tertiary);
-}
+.bl_cardUnit {
+	display: flex;
+	gap: 1rem;
 
-.bl_card.bl_card__clickable:hover {
-  background-color: var(--sc_bg_body__secondary);
+	&.bl_cardUnit__1col {
+		flex-flow: column nowrap;
+	}
 }
-
-.bl_card.bl_card__s {
-  font-size: 0.75rem;
-  color: var(--sc_txt_body__small);
-}
-
-.bl_card.bl_card__s.bl_card__clickable {
-  background-color: var(--sc_bg_body__primary);
-}
-
-.bl_card.bl_card__sticky {
-  border: var(--sc_border_alert);
-}
-
-.bl_card_thumbnail {
-  overflow: hidden;
-  border-top-left-radius: var(--card_r, 0);
-  border-top-right-radius: var(--card_r, 0);
-}
-
-.bl_card_thumbnail > img {
-  width: 100%;
-  height: auto;
-  aspect-ratio: 16/9;
-  object-fit: cover;
-  vertical-align: bottom;
-}
-
-.bl_card_body {
-  padding: 12px;
-}
-
-.bl_card_body .bl_card_category {
-  display: block;
-  margin-top: var(--space_1, 0.5rem);
-  margin-bottom: var(--space_1, 0.5rem);
-  font-size: 0.75em;
-  font-weight: 400;
-  line-height: 1.7;
-  color: var(--sc_txt_desc);
-  letter-spacing: 0.02em;
-}
-
-.bl_card_body .bl_card_title {
-  margin-top: var(--space_1, 0.5rem);
-  margin-bottom: var(--space_1, 0.5rem);
-  font-size: 1.5em;
-  font-weight: 500;
-  line-height: 1.5;
-  letter-spacing: 0.04em;
-}
-
-@media (min-width: 960px) {
-  .bl_card_body .bl_card_title {
-    font-size: 1.75em;
-    font-weight: 400;
-  }
-}
-
-.bl_card_body .bl_card_content {
-  font-size: 0.875em;
-  font-weight: 400;
-  line-height: 1.7;
-  letter-spacing: 0.04em;
-}
-
-.bl_card_body .bl_card_date {
-  font-size: 0.75em;
-  font-weight: 400;
-  line-height: 1.7;
-  color: var(--sc_txt_desc);
-  letter-spacing: 0.02em;
-}
-
 
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -662,7 +662,7 @@
 							<div class="bl_card_dates">
 								<div class="bl_card_date">
 									<span>投稿</span>
-									<time datetime="2023-07-21">2023/07/21</time>
+									<time datetime="2023-10-16">2023/10/16</time>
 								</div>
 								<!-- /.bl_card_date -->
 								<div class="bl_card_date">
@@ -690,12 +690,12 @@
 							<div class="bl_card_dates">
 								<div class="bl_card_date">
 									<span>投稿</span>
-									<time datetime="2023-07-28">2023/07/28</time>
+									<time datetime="2023-10-16">2023/10/16</time>
 								</div>
 								<!-- /.bl_card_date -->
 								<div class="bl_card_date">
 									<span>更新</span>
-									<time datetime="2023-07-31">2023/07/31</time>
+									<time datetime="2023-11-08">2023/11/08</time>
 								</div>
 								<!-- /.bl_card_date -->
 							</div>
@@ -706,9 +706,7 @@
 					<!-- /.bl_card_main -->
 					<div class="bl_card_meta">
 						<ul class="bl_card_categories" aria-label="カテゴリ">
-							<li><a href="./archive.html">Webアクセシビリティ</a></li>
 							<li><a href="./archive.html">サンプルページ</a></li>
-							<li><a href="./archive.html">WordPressテーマ</a></li>
 							<li><a href="./archive.html">ReadME</a></li>
 						</ul>
 						<!-- /.bl_card_categories -->
@@ -732,12 +730,12 @@
 							<div class="bl_card_dates">
 								<div class="bl_card_date">
 									<span>投稿</span>
-									<time datetime="2023-07-21">2023/07/21</time>
+									<time datetime="2023-10-16">2023/10/16</time>
 								</div>
 								<!-- /.bl_card_date -->
 								<div class="bl_card_date">
 									<span>更新</span>
-									<time datetime="2023-07-21">2023/07/22</time>
+									<time datetime="2023-11-01">2023/10/21</time>
 								</div>
 								<!-- /.bl_card_date -->
 							</div>
@@ -748,10 +746,8 @@
 					<!-- /.bl_card_main -->
 					<div class="bl_card_meta">
 						<ul class="bl_card_categories" aria-label="カテゴリ">
-							<li><a href="./archive.html">Webアクセシビリティ</a></li>
 							<li><a href="./archive.html">サンプルページ</a></li>
-							<li><a href="./archive.html">WordPressテーマ</a></li>
-							<li><a href="./archive.html">ReadME</a></li>
+							<li><a href="./archive.html">コンポーネント</a></li>
 						</ul>
 						<!-- /.bl_card_categories -->
 					</div>
@@ -771,12 +767,12 @@
 							<div class="bl_card_dates">
 								<div class="bl_card_date">
 									<span>投稿</span>
-									<time datetime="2023-07-21">2023/07/22</time>
+									<time datetime="2023-10-16">2023/10/16</time>
 								</div>
 								<!-- /.bl_card_date -->
 								<div class="bl_card_date">
 									<span>更新</span>
-									<time datetime="2023-07-21">2023/07/22</time>
+									<time datetime="2023-11-01">2023/10/21</time>
 								</div>
 								<!-- /.bl_card_date -->
 							</div>
@@ -787,10 +783,7 @@
 					<!-- /.bl_card_main -->
 					<div class="bl_card_meta">
 						<ul class="bl_card_categories" aria-label="カテゴリ">
-							<li><a href="./archive.html">Webアクセシビリティ</a></li>
 							<li><a href="./archive.html">サンプルページ</a></li>
-							<li><a href="./archive.html">WordPressテーマ</a></li>
-							<li><a href="./archive.html">ReadME</a></li>
 						</ul>
 						<!-- /.bl_card_categories -->
 					</div>
@@ -810,12 +803,12 @@
 							<div class="bl_card_dates">
 								<div class="bl_card_date">
 									<span>投稿</span>
-									<time datetime="2023-07-21">2023/07/21</time>
+									<time datetime="2023-10-16">2023/10/16</time>
 								</div>
 								<!-- /.bl_card_date -->
 								<div class="bl_card_date">
 									<span>更新</span>
-									<time datetime="2023-07-21">2023/07/22</time>
+									<time datetime="2023-11-01">2023/10/21</time>
 								</div>
 								<!-- /.bl_card_date -->
 							</div>
@@ -826,10 +819,7 @@
 					<!-- /.bl_card_main -->
 					<div class="bl_card_meta">
 						<ul class="bl_card_categories" aria-label="カテゴリ">
-							<li><a href="./archive.html">Webアクセシビリティ</a></li>
 							<li><a href="./archive.html">サンプルページ</a></li>
-							<li><a href="./archive.html">WordPressテーマ</a></li>
-							<li><a href="./archive.html">ReadME</a></li>
 						</ul>
 						<!-- /.bl_card_categories -->
 					</div>
@@ -849,12 +839,12 @@
 							<div class="bl_card_dates">
 								<div class="bl_card_date">
 									<span>投稿</span>
-									<time datetime="2023-07-21">2023/07/21</time>
+									<time datetime="2023-10-16">2023/10/16</time>
 								</div>
 								<!-- /.bl_card_date -->
 								<div class="bl_card_date">
 									<span>更新</span>
-									<time datetime="2023-07-21">2023/07/22</time>
+									<time datetime="2023-11-01">2023/10/21</time>
 								</div>
 								<!-- /.bl_card_date -->
 							</div>
@@ -865,10 +855,7 @@
 					<!-- /.bl_card_main -->
 					<div class="bl_card_meta">
 						<ul class="bl_card_categories" aria-label="カテゴリ">
-							<li><a href="./archive.html">Webアクセシビリティ</a></li>
 							<li><a href="./archive.html">サンプルページ</a></li>
-							<li><a href="./archive.html">WordPressテーマ</a></li>
-							<li><a href="./archive.html">ReadME</a></li>
 						</ul>
 						<!-- /.bl_card_categories -->
 					</div>
@@ -876,44 +863,6 @@
 				</article>
 				<!-- /.bl_card bl_card__clickable -->
 
-				<!-- TODO: アーカイブ -->
-				<article class="bl_card bl_card__clickable">
-					<a class="bl_card_main" href="./404.html">
-						<div class="bl_card_body">
-							<h2 class="bl_card_title">404</h2>
-							<p class="bl_card_content">
-								このページは 404ページ用のサンプルページとなります。
-								このパーツはアーカイブページ用のものです。
-							</p>
-							<div class="bl_card_dates">
-								<div class="bl_card_date">
-									<span>投稿</span>
-									<time datetime="2023-07-21">2023/07/21</time>
-								</div>
-								<!-- /.bl_card_date -->
-								<div class="bl_card_date">
-									<span>更新</span>
-									<time datetime="2023-07-21">2023/07/22</time>
-								</div>
-								<!-- /.bl_card_date -->
-							</div>
-							<!-- /.bl_card_dates -->
-						</div>
-						<!-- /.bl_card_body -->
-					</a>
-					<!-- /.bl_card_main -->
-					<div class="bl_card_meta">
-						<ul class="bl_card_categories" aria-label="カテゴリ">
-							<li><a href="./archive.html">Webアクセシビリティ</a></li>
-							<li><a href="./archive.html">サンプルページ</a></li>
-							<li><a href="./archive.html">WordPressテーマ</a></li>
-							<li><a href="./archive.html">ReadME</a></li>
-						</ul>
-						<!-- /.bl_card_categories -->
-					</div>
-					<!-- /.bl_card_meta -->
-				</article>
-				<!-- /.bl_card bl_card__clickable -->
 			</div>
 			<!-- /.bl_cardUnit bl_cardUnit__1col -->
     </main>
@@ -1364,19 +1313,20 @@
       <div class="ly_footer_widget6fr">
         <h2 class="ly_footer_headerTitle">最新の投稿</h2>
 				<div class="bl_cardUnit bl_cardUnit__1col">
+
 					<article class="bl_card bl_card__small bl_card__clickable">
 						<a class="bl_card_main" href="./single.html">
 							<div class="bl_card_body">
-								<h3 class="bl_card_title">Read me（サンプル：投稿ページ）</h3>
+								<h3 class="bl_card_title">Read me</h3>
 								<div class="bl_card_dates">
 									<div class="bl_card_date">
-										<span>投稿日</span>
-										<time datetime="2023-07-21">2023/07/21</time>
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
 									</div>
 									<!-- /.bl_card_date -->
 									<div class="bl_card_date">
-										<span>更新日</span>
-										<time datetime="2023-07-21">2023/07/22</time>
+										<span>更新</span>
+										<time datetime="2023-11-08">2023/11/08</time>
 									</div>
 									<!-- /.bl_card_date -->
 								</div>
@@ -1387,9 +1337,7 @@
 						<!-- /.bl_card_main -->
 						<div class="bl_card_meta">
 							<ul class="bl_card_categories" aria-label="カテゴリ">
-								<li><a href="./archive.html">Webアクセシビリティ</a></li>
 								<li><a href="./archive.html">サンプルページ</a></li>
-								<li><a href="./archive.html">WordPressテーマ</a></li>
 								<li><a href="./archive.html">ReadME</a></li>
 							</ul>
 							<!-- /.bl_card_categories -->
@@ -1404,13 +1352,13 @@
 								<h3 class="bl_card_title">サンプル：固定ページ</h3>
 								<div class="bl_card_dates">
 									<div class="bl_card_date">
-										<span>投稿日</span>
-										<time datetime="2023-07-21">2023/07/21</time>
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
 									</div>
 									<!-- /.bl_card_date -->
 									<div class="bl_card_date">
-										<span>更新日</span>
-										<time datetime="2023-07-21">2023/07/22</time>
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
 									</div>
 									<!-- /.bl_card_date -->
 								</div>
@@ -1421,10 +1369,8 @@
 						<!-- /.bl_card_main -->
 						<div class="bl_card_meta">
 							<ul class="bl_card_categories" aria-label="カテゴリ">
-								<li><a href="./archive.html">Webアクセシビリティ</a></li>
 								<li><a href="./archive.html">サンプルページ</a></li>
-								<li><a href="./archive.html">WordPressテーマ</a></li>
-								<li><a href="./archive.html">ReadME</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
 							</ul>
 							<!-- /.bl_card_categories -->
 						</div>
@@ -1438,13 +1384,13 @@
 								<h3 class="bl_card_title">サンプル：アーカイブ</h3>
 								<div class="bl_card_dates">
 									<div class="bl_card_date">
-										<span>投稿日</span>
-										<time datetime="2023-07-21">2023/07/21</time>
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
 									</div>
 									<!-- /.bl_card_date -->
 									<div class="bl_card_date">
-										<span>更新日</span>
-										<time datetime="2023-07-21">2023/07/22</time>
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
 									</div>
 									<!-- /.bl_card_date -->
 								</div>
@@ -1455,10 +1401,7 @@
 						<!-- /.bl_card_main -->
 						<div class="bl_card_meta">
 							<ul class="bl_card_categories" aria-label="カテゴリ">
-								<li><a href="./archive.html">Webアクセシビリティ</a></li>
 								<li><a href="./archive.html">サンプルページ</a></li>
-								<li><a href="./archive.html">WordPressテーマ</a></li>
-								<li><a href="./archive.html">ReadME</a></li>
 							</ul>
 							<!-- /.bl_card_categories -->
 						</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -636,127 +636,286 @@
     <!--≡≡≡ ▲ sidebar-left.php ▲ ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡-->
 
     <main class="ly_mainArea_content ly_mainArea_content__middle" id="anchor_mainContent">
-      <article class="bl_card_wrapper">
-        <div class="bl_card bl_card__sticky">
-          <div class="bl_card_body">
-            <span class="bl_card_category">カテゴリー欄</span>
-            <h2 class="bl_card_title">タイトル欄</h2>
-            <p class="bl_card_content">記事の要旨欄</p>
-            <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </div>
-        <!-- /.bl_card bl_card__sticky -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+			<div class="bl_cardUnit bl_cardUnit__1col">
 
-      <article class="bl_card_wrapper">
-        <div class="bl_card">
-          <div class="bl_card_thumbnail">
-            <img src="./assets/images/m_02_white.png">
-          </div>
-          <!-- /.bl_card_thumbnail -->
-          <div class="bl_card_body">
-            <span class="bl_card_category">Webアクセシビリティ</span>
-            <h2 class="bl_card_title">このサイトについて</h2>
-            <p class="bl_card_content">このサイトは、デジタル庁の「デザインシステム」を基に試作したものになります。</p>
-            <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </div>
-        <!-- /.bl_card -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__sticky" aria-label="固定表示に設定された記事">
+					<div class="bl_card_main">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">タイトル欄</h2>
+							<p class="bl_card_content">記事の要旨欄</p>
+						</div>
+						<!-- /.bl_card_body -->
+					</div>
+					<!-- /.bl_card_main -->
+				</article>
+				<!-- /.bl_card bl_card__sticky -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./single.html">
-          <div class="bl_card_body">
-            <span class="bl_card_category">サンプルページ</span>
-            <h2 class="bl_card_title">Read me</h2>
-            <p class="bl_card_content">
-              ここでは、このプロジェクトの主旨や注意事項等についてまとめてあります。
-              また、投稿ページのサンプルも兼ねています。
-            </p>
-            <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card">
+					<div class="bl_card_main">
+						<div class="bl_card_thumbnail">
+							<img src="./assets/images/m_02_white.png">
+						</div>
+						<!-- /.bl_card_thumbnail -->
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">このサイトについて</h2>
+							<p class="bl_card_content">このサイトは、デジタル庁の「デザインシステム」を基に試作したものになります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-07-21">2023/07/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-15">2023/11/15</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</div>
+					<!-- /.bl_card_main -->
+				</article>
+				<!-- /.bl_card -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./page.html">
-          <div class="bl_card_thumbnail">
-            <img src="./assets/images/m_02_white.png">
-          </div>
-          <!-- /.bl_card_thumbnail -->
-          <div class="bl_card_body">
-            <span class="bl_card_category">サンプルページ</span>
-            <h2 class="bl_card_title">サンプル：固定ページ</h2>
-            <p class="bl_card_content">このページは 固定ページ用のサンプルページとなります。</p>
-            <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./single.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">Read me</h2>
+							<p class="bl_card_content">
+								ここでは、このプロジェクトの主旨や注意事項等についてまとめてあります。
+								また、投稿ページのサンプルも兼ねています。
+							</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-07-28">2023/07/28</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-07-31">2023/07/31</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">Webアクセシビリティ</a></li>
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">WordPressテーマ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./archive.html">
-          <div class="bl_card_thumbnail">
-            <img src="./assets/images/m_02_white.png">
-          </div>
-          <!-- /.bl_card_thumbnail -->
-          <div class="bl_card_body">
-            <span class="bl_card_category">サンプルページ</span>
-            <h2 class="bl_card_title">サンプル：アーカイブ</h2>
-            <p class="bl_card_content">このページは アーカイブページ用のサンプルページとなります。</p>
-            <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./page.html">
+						<div class="bl_card_thumbnail">
+							<img src="./assets/images/m_02_white.png">
+						</div>
+						<!-- /.bl_card_thumbnail -->
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：固定ページ</h2>
+							<p class="bl_card_content">
+								このページは 固定ページ用のサンプルページとなります。
+								ここでは、本テーマで使用しているコンポーネントの一部を、一覧として掲示しております。
+							</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-07-21">2023/07/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-07-21">2023/07/22</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">Webアクセシビリティ</a></li>
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">WordPressテーマ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./search.html">
-          <div class="bl_card_thumbnail">
-            <img src="./assets/images/m_02_white.png">
-          </div>
-          <!-- /.bl_card_thumbnail -->
-          <div class="bl_card_body">
-            <span class="bl_card_category">サンプルページ</span>
-            <h2 class="bl_card_title">サンプル：検索</h2>
-            <p class="bl_card_content">このページは 検索ページ用のサンプルページとなります。</p>
-            <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./archive.html">
+						<div class="bl_card_thumbnail">
+							<img src="./assets/images/m_02_white.png">
+						</div>
+						<!-- /.bl_card_thumbnail -->
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：アーカイブ</h2>
+							<p class="bl_card_content">このページは アーカイブページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-07-21">2023/07/22</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-07-21">2023/07/22</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">Webアクセシビリティ</a></li>
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">WordPressテーマ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./404.html">
-          <div class="bl_card_thumbnail">
-            <img src="./assets/images/m_02_white.png">
-          </div>
-          <!-- /.bl_card_thumbnail -->
-          <div class="bl_card_body">
-            <span class="bl_card_category">サンプルページ</span>
-            <h2 class="bl_card_title">サンプル：404</h2>
-            <p class="bl_card_content">このページは 404のサンプルページとなります。</p>
-            <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./search.html">
+						<div class="bl_card_thumbnail">
+							<img src="./assets/images/m_02_white.png">
+						</div>
+						<!-- /.bl_card_thumbnail -->
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：検索</h2>
+							<p class="bl_card_content">このページは 検索ページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-07-21">2023/07/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-07-21">2023/07/22</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">Webアクセシビリティ</a></li>
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">WordPressテーマ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./404.html">
+						<div class="bl_card_thumbnail">
+							<img src="./assets/images/m_02_white.png">
+						</div>
+						<!-- /.bl_card_thumbnail -->
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：404</h2>
+							<p class="bl_card_content">このページは 404ページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-07-21">2023/07/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-07-21">2023/07/22</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">Webアクセシビリティ</a></li>
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">WordPressテーマ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
+
+				<!-- TODO: アーカイブ -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./404.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">404</h2>
+							<p class="bl_card_content">
+								このページは 404ページ用のサンプルページとなります。
+								このパーツはアーカイブページ用のものです。
+							</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-07-21">2023/07/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-07-21">2023/07/22</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">Webアクセシビリティ</a></li>
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">WordPressテーマ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
+			</div>
+			<!-- /.bl_cardUnit bl_cardUnit__1col -->
     </main>
     <!-- /.ly_mainArea_content -->
 
@@ -1204,39 +1363,110 @@
 
       <div class="ly_footer_widget6fr">
         <h2 class="ly_footer_headerTitle">最新の投稿</h2>
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./single.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">Read me（サンプル：投稿ページ）</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./page.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：固定ページ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./archive.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：アーカイブ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
+				<div class="bl_cardUnit bl_cardUnit__1col">
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./single.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">Read me（サンプル：投稿ページ）</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿日</span>
+										<time datetime="2023-07-21">2023/07/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新日</span>
+										<time datetime="2023-07-21">2023/07/22</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">Webアクセシビリティ</a></li>
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">WordPressテーマ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：固定ページ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿日</span>
+										<time datetime="2023-07-21">2023/07/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新日</span>
+										<time datetime="2023-07-21">2023/07/22</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">Webアクセシビリティ</a></li>
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">WordPressテーマ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./archive.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：アーカイブ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿日</span>
+										<time datetime="2023-07-21">2023/07/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新日</span>
+										<time datetime="2023-07-21">2023/07/22</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">Webアクセシビリティ</a></li>
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">WordPressテーマ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+				</div>
+				<!-- /.bl_cardUnit bl_cardUnit__1col -->
       </div>
       <!-- /.ly_footer_widget6fr -->
 

--- a/docs/page.html
+++ b/docs/page.html
@@ -517,97 +517,179 @@
       <!-- Component:Card -->
       <div class="bl_component_box">
         <h3 class="bl_component_caption">カード</h3>
+
         <div class="bl_component_box">
-          <h4 class="bl_component_caption">サムネイル無、クリック不可、スティッキー</h4>
-          <article class="bl_card_wrapper">
-            <div class="bl_card bl_card__sticky">
-              <div class="bl_card_body">
-                <span class="bl_card_category">カテゴリー欄</span>
-                <h2 class="bl_card_title">タイトル欄</h2>
-                <p class="bl_card_content">記事の要旨欄</p>
-                <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-              </div>
-              <!-- /.bl_card_body -->
-            </div>
-            <!-- /.bl_card bl_card__sticky -->
-          </article>
+          <h4 class="bl_component_caption">クリック不可、サムネイル無、スティッキー</h4>
+
+					<article class="bl_card bl_card__sticky" aria-label="固定表示に設定された記事">
+						<div class="bl_card_main">
+							<div class="bl_card_body">
+								<h2 class="bl_card_title">タイトル欄</h2>
+								<p class="bl_card_content">記事の要旨欄</p>
+							</div>
+							<!-- /.bl_card_body -->
+						</div>
+						<!-- /.bl_card_main -->
+					</article>
+					<!-- /.bl_card bl_card__sticky -->
+
         </div>
 
         <div class="bl_component_box">
-          <h4 class="bl_component_caption">サムネイル付、クリック不可</h4>
-          <article class="bl_card_wrapper">
-            <div class="bl_card">
-              <div class="bl_card_thumbnail">
-                <img src="./assets/images/m_02_white.png" />
-              </div>
-              <!-- /.bl_card_thumbnail -->
-              <div class="bl_card_body">
-                <span class="bl_card_category">Webアクセシビリティ</span>
-                <h2 class="bl_card_title">このサイトについて</h2>
-                <p class="bl_card_content">
-                  このサイトは、デジタル庁の「デザインシステム」を基に試作したものになります。
-                </p>
-                <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-              </div>
-              <!-- /.bl_card_body -->
-            </div>
-            <!-- /.bl_card -->
-          </article>
-          <!-- /.bl_card_wrapper -->
+          <h4 class="bl_component_caption">クリック不可、基本形（サムネイル、タイトル、要旨、日付データ）</h4>
+
+					<article class="bl_card">
+						<div class="bl_card_main">
+							<div class="bl_card_thumbnail">
+								<img src="./assets/images/m_02_white.png">
+							</div>
+							<!-- /.bl_card_thumbnail -->
+							<div class="bl_card_body">
+								<h2 class="bl_card_title">このサイトについて</h2>
+								<p class="bl_card_content">このサイトは、デジタル庁の「デザインシステム」を基に試作したものになります。</p>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-15">2023/11/15</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</div>
+						<!-- /.bl_card_main -->
+					</article>
+					<!-- /.bl_card -->
+
         </div>
 
         <div class="bl_component_box">
-          <h4 class="bl_component_caption">サムネイル付、クリック可能</h4>
-          <article class="bl_card_wrapper">
-            <a class="bl_card bl_card__clickable" href="#">
-              <div class="bl_card_thumbnail">
-                <img src="./assets/images/m_02_white.png" />
-              </div>
-              <!-- /.bl_card_thumbnail -->
-              <div class="bl_card_body">
-                <span class="bl_card_category">サンプルページ</span>
-                <h2 class="bl_card_title">サンプル：固定ページ</h2>
-                <p class="bl_card_content">
-                  このページは 固定ページ用のサンプルページとなります。
-                </p>
-                <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-              </div>
-              <!-- /.bl_card_body -->
-            </a>
-            <!-- /.bl_card bl_card__clickable -->
-          </article>
-          <!-- /.bl_card_wrapper -->
+          <h4 class="bl_component_caption">クリック可、基本形にメタ情報付与</h4>
+
+					<article class="bl_card bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_thumbnail">
+								<img src="./assets/images/m_02_white.png">
+							</div>
+							<!-- /.bl_card_thumbnail -->
+							<div class="bl_card_body">
+								<h2 class="bl_card_title">サンプル：固定ページ</h2>
+								<p class="bl_card_content">
+									このページは 固定ページ用のサンプルページとなります。
+									ここでは、本テーマで使用しているコンポーネントの一部を、一覧として掲示しております。
+								</p>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__clickable -->
+
         </div>
 
         <div class="bl_component_box">
-          <h4 class="bl_component_caption">サムネイル無、クリック可能（アーカイブ、検索ページに使用）</h4>
-          <article class="bl_card_wrapper">
-            <a class="bl_card bl_card__clickable" href="./page.html">
-              <div class="bl_card_body">
-                <p class="bl_card_category">サンプルページ</p>
-                <h2 class="bl_card_title">固定ページ</h2>
-                <time class="bl_card_date" datetime="2020-10-23">2020年10月23日</time>
-              </div>
-              <!-- /.bl_card_body -->
-            </a>
-            <!-- /.bl_card bl_card__clickable -->
-          </article>
-          <!-- /.bl_card_wrapper -->
+          <h4 class="bl_component_caption">クリック可、基本形からサムネイル除去（アーカイブ＆検索ページに使用）</h4>
+
+					<article class="bl_card bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h2 class="bl_card_title">サンプル：固定ページ</h2>
+								<p class="bl_card_content">
+									このページは 固定ページ用のサンプルページとなります。
+									ここでは、本テーマで使用しているコンポーネントの一部を、一覧として掲示しております。
+								</p>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__clickable -->
+
         </div>
 
         <div class="bl_component_box">
-          <h4 class="bl_component_caption">サムネイル無、クリック可能、小サイズ（フッター「最新の投稿」に使用）</h4>
-          <article class="bl_card_wrapper">
-            <a class="bl_card bl_card__s bl_card__clickable" href="#">
-              <div class="bl_card_body">
-                <h2 class="bl_card_title">Read me（サンプル：投稿ページ）</h2>
-                <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-              </div>
-              <!-- /.bl_card_body -->
-            </a>
-            <!-- /.bl_card bl_card__s bl_card__clickable -->
-          </article>
-          <!-- /.bl_card_wrapper -->
+          <h4 class="bl_component_caption">クリック可、上記から小サイズし要旨を除去（フッター「最新の投稿」に使用）</h4>
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：固定ページ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
         </div>
       </div>
 
@@ -1583,7 +1665,7 @@
     <div class="ly_footer">
       <div class="ly_footer_widget3fr">
         <div class="ly_footer_headerTitle">
-          <img src="./assets/images/Dummy_logo.PNG" alt="Logo" />
+          <img src="./assets/images/Dummy_logo.PNG" alt="Logo">
           <span>Web-Zukuri</span>
         </div>
         <!-- /.ly_footer_headerTitle -->
@@ -1642,44 +1724,110 @@
         </div>
         <!-- /.bl_tagMenu -->
         <!--≡≡≡ ▲ template-parts/parts-menu.php[main] ▲ ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡-->
+
       </div>
       <!-- /.ly_footer_widget3fr -->
 
       <div class="ly_footer_widget6fr">
         <h2 class="ly_footer_headerTitle">最新の投稿</h2>
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./single.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">Read me（サンプル：投稿ページ）</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./page.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：固定ページ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./archive.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：アーカイブ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
+				<div class="bl_cardUnit bl_cardUnit__1col">
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./single.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">Read me</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-08">2023/11/08</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：固定ページ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./archive.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：アーカイブ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+				</div>
+				<!-- /.bl_cardUnit bl_cardUnit__1col -->
       </div>
       <!-- /.ly_footer_widget6fr -->
 
@@ -1692,14 +1840,14 @@
           <a href="#" class="bl_snsIcon_item">
             <svg role="graphics-symbol" aria-label="Twitter" version="1.1" id="Layer_1"
               xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-              viewBox="0 0 400 400" style="enable-background: new 0 0 400 400" xml:space="preserve">
+              viewBox="0 0 400 400" style="enable-background:new 0 0 400 400;" xml:space="preserve">
               <style type="text/css">
                 .st0 {
-                  fill: #1b9df0;
+                  fill: #1B9DF0;
                 }
 
                 .st1 {
-                  fill: #ffffff;
+                  fill: #FFFFFF;
                 }
               </style>
               <g id="Dark_Blue">

--- a/docs/search.html
+++ b/docs/search.html
@@ -612,70 +612,178 @@
       <h2 class="el_header_lv2">検索結果</h2>
       <p>「***」の検索結果</p>
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./single.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">投稿ページ(Read me)</h2>
-            <time class="bl_card_date" datetime="2020-11-22">2020年11月22日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+			<div class="bl_cardUnit bl_cardUnit__1col">
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./page.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">固定ページ</h2>
-            <time class="bl_card_date" datetime="2020-10-23">2020年10月23日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./single.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">Read me</h2>
+							<p class="bl_card_content">
+								ここでは、このプロジェクトの主旨や注意事項等についてまとめてあります。
+								また、投稿ページのサンプルも兼ねています。
+							</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-08">2023/11/08</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">ReadME</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./archive.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">アーカイブ</h2>
-            <time class="bl_card_date" datetime="2020-09-16">2020年9月16日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./page.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：固定ページ</h2>
+							<p class="bl_card_content">
+								このページは 固定ページ用のサンプルページとなります。
+								ここでは、本テーマで使用しているコンポーネントの一部を、一覧として掲示しております。
+							</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+							<li><a href="./archive.html">コンポーネント</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./search.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">検索</h2>
-            <time class="bl_card_date" datetime="2020-08-01">2020年8月1日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./archive.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：アーカイブ</h2>
+							<p class="bl_card_content">このページは アーカイブページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
 
-      <article class="bl_card_wrapper">
-        <a class="bl_card bl_card__clickable" href="./404.html">
-          <div class="bl_card_body">
-            <p class="bl_card_category">サンプルページ</p>
-            <h2 class="bl_card_title">404</h2>
-            <time class="bl_card_date" datetime="2020-07-16">2020年7月16日</time>
-          </div>
-          <!-- /.bl_card_body -->
-        </a>
-        <!-- /.bl_card bl_card__clickable -->
-      </article>
-      <!-- /.bl_card_wrapper -->
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./search.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：検索</h2>
+							<p class="bl_card_content">このページは 検索ページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
+
+				<article class="bl_card bl_card__clickable">
+					<a class="bl_card_main" href="./404.html">
+						<div class="bl_card_body">
+							<h2 class="bl_card_title">サンプル：404</h2>
+							<p class="bl_card_content">このページは 404ページ用のサンプルページとなります。</p>
+							<div class="bl_card_dates">
+								<div class="bl_card_date">
+									<span>投稿</span>
+									<time datetime="2023-10-16">2023/10/16</time>
+								</div>
+								<!-- /.bl_card_date -->
+								<div class="bl_card_date">
+									<span>更新</span>
+									<time datetime="2023-11-01">2023/10/21</time>
+								</div>
+								<!-- /.bl_card_date -->
+							</div>
+							<!-- /.bl_card_dates -->
+						</div>
+						<!-- /.bl_card_body -->
+					</a>
+					<!-- /.bl_card_main -->
+					<div class="bl_card_meta">
+						<ul class="bl_card_categories" aria-label="カテゴリ">
+							<li><a href="./archive.html">サンプルページ</a></li>
+						</ul>
+						<!-- /.bl_card_categories -->
+					</div>
+					<!-- /.bl_card_meta -->
+				</article>
+				<!-- /.bl_card bl_card__clickable -->
+
+			</div>
+			<!-- /.bl_cardUnit bl_cardUnit__1col -->
 
       <nav class="bl_pager" aria-label="ページ割り">
         <div class="bl_pager_left">
@@ -1157,39 +1265,104 @@
 
       <div class="ly_footer_widget6fr">
         <h2 class="ly_footer_headerTitle">最新の投稿</h2>
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./single.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">Read me（サンプル：投稿ページ）</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./page.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：固定ページ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./archive.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：アーカイブ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
+				<div class="bl_cardUnit bl_cardUnit__1col">
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./single.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">Read me</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-08">2023/11/08</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：固定ページ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./archive.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：アーカイブ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+				</div>
+				<!-- /.bl_cardUnit bl_cardUnit__1col -->
       </div>
       <!-- /.ly_footer_widget6fr -->
 

--- a/docs/single.html
+++ b/docs/single.html
@@ -1257,39 +1257,104 @@
 
       <div class="ly_footer_widget6fr">
         <h2 class="ly_footer_headerTitle">最新の投稿</h2>
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./single.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">Read me（サンプル：投稿ページ）</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./page.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：固定ページ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
-        <article class="bl_card_wrapper">
-          <a class="bl_card bl_card__s bl_card__clickable" href="./archive.html">
-            <div class="bl_card_body">
-              <h2 class="bl_card_title">サンプル：アーカイブ</h2>
-              <time class="bl_card_date" datetime="2023-07-21">2023/07/21</time>
-            </div>
-            <!-- /.bl_card_body -->
-          </a>
-          <!-- /.bl_card bl_card__s bl_card__clickable -->
-        </article>
-        <!-- /.bl_card_wrapper -->
+				<div class="bl_cardUnit bl_cardUnit__1col">
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./single.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">Read me</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-08">2023/11/08</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">ReadME</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./page.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：固定ページ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+								<li><a href="./archive.html">コンポーネント</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+
+					<article class="bl_card bl_card__small bl_card__clickable">
+						<a class="bl_card_main" href="./archive.html">
+							<div class="bl_card_body">
+								<h3 class="bl_card_title">サンプル：アーカイブ</h3>
+								<div class="bl_card_dates">
+									<div class="bl_card_date">
+										<span>投稿</span>
+										<time datetime="2023-10-16">2023/10/16</time>
+									</div>
+									<!-- /.bl_card_date -->
+									<div class="bl_card_date">
+										<span>更新</span>
+										<time datetime="2023-11-01">2023/10/21</time>
+									</div>
+									<!-- /.bl_card_date -->
+								</div>
+								<!-- /.bl_card_dates -->
+							</div>
+							<!-- /.bl_card_body -->
+						</a>
+						<!-- /.bl_card_main -->
+						<div class="bl_card_meta">
+							<ul class="bl_card_categories" aria-label="カテゴリ">
+								<li><a href="./archive.html">サンプルページ</a></li>
+							</ul>
+							<!-- /.bl_card_categories -->
+						</div>
+						<!-- /.bl_card_meta -->
+					</article>
+					<!-- /.bl_card bl_card__small bl_card__clickable -->
+				</div>
+				<!-- /.bl_cardUnit bl_cardUnit__1col -->
       </div>
       <!-- /.ly_footer_widget6fr -->
 


### PR DESCRIPTION
# 今回の作業について

カードコンポーネントを、大幅に作り直し改善していくことが目的である。

+ 各種カードにメタ情報（カテゴリ）を入れる欄を追加、そこから該当カテゴリのアーカイブへリンクできるようにも
+ フロント、アーカイブ、検索でのカードには要旨を入れられるよう調整
+ 投稿日と更新日の欄を整備

## 現状について

+ HTML側での大まかな改修が終了。
+ CSSは作成優先で、ネストした状態だったりと最適化されていない

## 今後の作業について

1. GitHub Pages で動作確認
2. 問題なければCSSをリファクタリング
3. HTMLでの内容をWordPress側に反映